### PR TITLE
Refactor BERTScore metric to use real BERTScorer

### DIFF
--- a/run_experiments.py
+++ b/run_experiments.py
@@ -57,7 +57,7 @@ def _prompt_heuristic(context: str, sentence: str) -> str:
 MetricFactory = Dict[str, Callable[[], object]]
 
 METRICS: MetricFactory = {
-    "bertscore": lambda: SelfCheckBERTScore(use_bert_score=False),
+    "bertscore": SelfCheckBERTScore,
     "mqag": SelfCheckMQAG,
     "ngram": SelfCheckNgram,
     "nli": SelfCheckNLI,


### PR DESCRIPTION
## Summary
- use `BERTScorer` by default in `SelfCheckBERTScore` with configurable model and baseline
- expose BERTScore metric in experiment runner
- add tests comparing wrapper scores to raw BERTScorer outputs

## Testing
- `pytest -q`