### PR TITLE
Add GPU setup script and experiment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ python -m spacy download en_core_web_sm
 python -c "from data.utils import load_wikibio_hallucination; load_wikibio_hallucination(split='train[:1]')"
 ```
 
+## GPU setup (RTX 4060)
+
+Running the heavier metrics on GPU requires a recent NVIDIA driver and a
+CUDA‑enabled PyTorch build.  An RTX 4060 supports CUDA 12, which in turn needs
+driver version 535 or newer.  The repository ships a helper script that
+installs the CUDA 12.1 toolkit, PyTorch with matching CUDA wheels and downloads
+all Hugging Face weights used by BERTScore, MQAG and NLI:
+
+```bash
+bash scripts/setup_gpu_env.sh
+```
+
+The script fetches the following models in advance so that the first run does
+not need to contact Hugging Face:
+
+- `roberta-large` for BERTScore
+- `potsawee/t5-base-squad-qg`, `potsawee/t5-base-distractor-generation`,
+  `potsawee/longformer-large-4096-mc-squad2` and
+  `potsawee/longformer-large-4096-answerable-squad2` for MQAG
+- `microsoft/deberta-v3-large-mnli` for NLI
+
 ## Running experiments
 
 By default the script evaluates the n‑gram metric on fifty examples:
@@ -99,6 +120,17 @@ Every run writes a ``summary.csv`` file and generates precision/recall
 and calibration plots for each metric, reproducing the statistics
 reported in the paper (precision, recall, F1, average precision, Brier
 score and calibration curves).
+
+To mirror the paper exactly with GPU‑accelerated metrics run:
+
+```bash
+python run_experiments.py --metrics ngram bertscore mqag nli --paper-config
+```
+
+Results are placed in the directory given by ``--output-dir`` (``results`` by
+default).  It will contain ``summary.csv``, per‑metric ``*_pr.png`` and
+``*_calibration.png`` plots and, when multiple metrics are combined, the trained
+logistic‑regression weights in ``combiner.pt``.
 
 ## LLM configuration
 

--- a/scripts/setup_gpu_env.sh
+++ b/scripts/setup_gpu_env.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Sample environment setup for running SelfCheckGPT metrics on an RTX 4060.
+# Installs CUDA Toolkit 12.1, matching PyTorch wheels and downloads
+# required Hugging Face model weights.
+
+set -euo pipefail
+
+# Install NVIDIA driver and CUDA Toolkit (Ubuntu 22.04 example)
+sudo apt-get update
+sudo apt-get install -y nvidia-driver-535
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda-repo-ubuntu2204-12-1-local_12.1.1-530.30.02-1_amd64.deb
+sudo dpkg -i cuda-repo-ubuntu2204-12-1-local_12.1.1-530.30.02-1_amd64.deb
+sudo apt-get update
+sudo apt-get install -y cuda-toolkit-12-1
+
+# CUDA environment variables
+export PATH=/usr/local/cuda-12.1/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH
+
+# Install PyTorch with CUDA 12.1 support
+pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu121
+
+# Pre-download required Hugging Face model weights
+python - <<'PY'
+from transformers import (
+    AutoTokenizer,
+    AutoModel,
+    AutoModelForSeq2SeqLM,
+    AutoModelForSequenceClassification,
+    LongformerForMultipleChoice,
+)
+
+models = {
+    "roberta-large": AutoModel,
+    "potsawee/t5-base-squad-qg": AutoModelForSeq2SeqLM,
+    "potsawee/t5-base-distractor-generation": AutoModelForSeq2SeqLM,
+    "potsawee/longformer-large-4096-mc-squad2": LongformerForMultipleChoice,
+    "potsawee/longformer-large-4096-answerable-squad2": AutoModelForSequenceClassification,
+    "microsoft/deberta-v3-large-mnli": AutoModelForSequenceClassification,
+}
+
+for name, cls in models.items():
+    print(f"Downloading {name}...")
+    cls.from_pretrained(name)
+    AutoTokenizer.from_pretrained(name)
+PY
+
+echo "GPU environment setup complete."


### PR DESCRIPTION
## Summary
- document CUDA/PyTorch setup and model downloads for RTX 4060
- add `scripts/setup_gpu_env.sh` to install CUDA toolkit, PyTorch and fetch required models
- explain running `run_experiments.py --paper-config` and where outputs are saved

## Testing
- `pytest -q`