### PR TITLE
Use evaluation split by default for WikiBio dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ model. After installing the Python dependencies, download these resources:
 ```bash
 pip install -r requirements.txt
 python -m spacy download en_core_web_sm
-python -c "from data.utils import load_wikibio_hallucination; load_wikibio_hallucination(split='train[:1]')"
+python -c "from data.utils import load_wikibio_hallucination; load_wikibio_hallucination(split='evaluation[:1]')"
 ```
 
 ## GPU setup (RTX 4060)
@@ -98,10 +98,12 @@ python run_experiments.py --metrics ngram mqag nli --limit 25
 
 Use ``--train-split``, ``--val-split`` and ``--test-split`` to select dataset
 partitions for training the combiner, optional validation, and final
-evaluation.  Splits accept the usual Hugging Face slicing syntax:
+evaluation.  The WikiBio hallucination dataset only provides an
+``evaluation`` split, so different slices of it can be used for the
+individual stages:
 
 ```bash
-python run_experiments.py --train-split train[:1000] --val-split validation[:200] --test-split test --metrics all --sample-count 20
+python run_experiments.py --train-split evaluation[:1000] --val-split evaluation[1000:1200] --test-split evaluation[1200:2000] --metrics all --sample-count 20
 ```
 
 The ``--sample-count`` flag controls how many sampled passages per

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -196,19 +196,19 @@ def main() -> None:  # pragma: no cover - exercised via CLI
     parser.add_argument(
         "--train-split",
         type=str,
-        default="train",
+        default="evaluation",
         help="Dataset split or slice for training the combiner.",
     )
     parser.add_argument(
         "--val-split",
         type=str,
-        default="validation",
+        default=None,
         help="Optional dataset split or slice for validation/hyperparameters.",
     )
     parser.add_argument(
         "--test-split",
         type=str,
-        default="test",
+        default="evaluation",
         help="Dataset split or slice for final evaluation.",
     )
     parser.add_argument(

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -17,7 +17,7 @@ def test_spacy_model_loads():
 def test_wikibio_dataset_loads(tmp_path):
     try:
         ds = load_wikibio_hallucination(
-            split="train[:1]", cache_dir=tmp_path
+            split="evaluation[:1]", cache_dir=tmp_path
         )
     except Exception as exc:  # pragma: no cover - network failure
         pytest.skip(f"dataset download failed: {exc}")

--- a/tests/test_run_experiments_integration.py
+++ b/tests/test_run_experiments_integration.py
@@ -38,11 +38,11 @@ def test_run_experiments_tiny(tmp_path, monkeypatch):
             "--output-dir",
             str(out_dir),
             "--train-split",
-            "train[:1]",
+            "evaluation[:1]",
             "--val-split",
-            "validation[:1]",
+            "evaluation[:1]",
             "--test-split",
-            "test[:1]",
+            "evaluation[:1]",
         ],
     )
     run_experiments.main()
@@ -54,7 +54,7 @@ def test_run_experiments_tiny(tmp_path, monkeypatch):
     assert (out_dir / "combiner.pt").exists()
     content = summary.read_text()
     assert "ngram" in content
-    assert seen_splits == ["train[:1]", "validation[:1]", "test[:1]"]
+    assert seen_splits == ["evaluation[:1]", "evaluation[:1]", "evaluation[:1]"]
 
 
 def test_run_experiments_temperature_sweep(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- default to evaluation split for training and testing since WikiBio hallucination dataset only provides that partition
- document evaluation-only data in README and update tests accordingly

## Testing
- `pytest`