### PR TITLE
Fix misspelled project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SlefCheckGPT
+# SelfCheckGPT
 
 This repository provides a **light‑weight educational reimplementation** of
 several ideas from the paper

--- a/results/overnight/20250814_184213/manifest.json
+++ b/results/overnight/20250814_184213/manifest.json
@@ -18,28 +18,28 @@
     {
         "name":  "openai_prompt_smoke",
         "ok":  true,
-        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\results\\overnight\\20250814_184213\\online\\prompt_smoke_gpt-4o-mini",
+        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\results\\overnight\\20250814_184213\\online\\prompt_smoke_gpt-4o-mini",
         "limit":  20,
         "model":  "gpt-4o-mini"
     },
     {
         "name":  "openai_resample_smoke",
         "ok":  true,
-        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\results\\overnight\\20250814_184213\\online\\resample_smoke_gpt-4o-mini",
+        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\results\\overnight\\20250814_184213\\online\\resample_smoke_gpt-4o-mini",
         "limit":  20,
         "model":  "gpt-4o-mini"
     },
     {
         "name":  "openai_combined",
         "ok":  true,
-        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\results\\overnight\\20250814_184213\\online\\combined_100_gpt-4o-mini",
+        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\results\\overnight\\20250814_184213\\online\\combined_100_gpt-4o-mini",
         "limit":  100,
         "model":  "gpt-4o-mini"
     },
     {
         "name":  "offline_gpu_demo_smoke_tuned",
         "ok":  true,
-        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\results\\overnight\\20250814_184213\\offline\\gpu_demo_smoke_tuned",
+        "outDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\results\\overnight\\20250814_184213\\offline\\gpu_demo_smoke_tuned",
         "limit":  20
     }
 ]

--- a/results/overnight/20250814_184213/run_config.json
+++ b/results/overnight/20250814_184213/run_config.json
@@ -6,8 +6,8 @@
                    "full":  100,
                    "smoke":  20
                },
-    "resultsRoot":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\results",
-    "runDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\results\\overnight\\20250814_184213",
-    "hfHome":  "C:\\Users\\meddh\\Documents\\GitHub\\SlefCheckGPT\\hf-cache",
+    "resultsRoot":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\results",
+    "runDir":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\results\\overnight\\20250814_184213",
+    "hfHome":  "C:\\Users\\meddh\\Documents\\GitHub\\SelfCheckGPT\\hf-cache",
     "transformersOffline":  "1"
 }


### PR DESCRIPTION
## Summary
- Correct all references from `SlefCheckGPT` to `SelfCheckGPT`
- Update result configuration paths to match the corrected name

## Testing
- `pytest -q`